### PR TITLE
[COR-2884] Clean up repo + add overlays

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 4f4a8d8c-90c5-4992-8800-17a249fd1e0f
 management:
-  docChecksum: e49e26d18bf53a407c88d0d884232774
+  docChecksum: 243c544516bdc9c3dfb020e62e2e9b1a
   docVersion: "1.0"
-  speakeasyVersion: 1.543.8
-  generationVersion: 2.598.22
-  releaseVersion: 0.0.2
-  configChecksum: cc81664a14dc8fc4d49f56b2a09bc011
+  speakeasyVersion: 1.544.0
+  generationVersion: 2.599.0
+  releaseVersion: 0.0.3
+  configChecksum: d819fadb3f02193b519f697841029edc
 features:
   typescript:
     additionalDependencies: 0.1.0

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -19,7 +19,7 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 typescript:
-  version: 0.0.2
+  version: 0.0.3
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.543.8
+speakeasyVersion: 1.544.0
 sources:
     Opal API:
         sourceNamespace: opal-api
-        sourceRevisionDigest: sha256:332e10438c1e50b62df321238970151272af2792100c75281b8360809fabd46f
-        sourceBlobDigest: sha256:78aa8a6e8985f194353a2b4d2d1e3d2f2cadde7c91194f695f0419c2db5d3467
+        sourceRevisionDigest: sha256:082ea6cf007b282f6c8ed83c0c444dcec872e4475d7dfe406b687fc55646a6dc
+        sourceBlobDigest: sha256:b5e808cce8225b044c356512b28ba189f97e5af6648c07aaf54fd837592e7f23
         tags:
             - latest
             - "1.0"
@@ -11,10 +11,10 @@ targets:
     opal-mcp:
         source: Opal API
         sourceNamespace: opal-api
-        sourceRevisionDigest: sha256:332e10438c1e50b62df321238970151272af2792100c75281b8360809fabd46f
-        sourceBlobDigest: sha256:78aa8a6e8985f194353a2b4d2d1e3d2f2cadde7c91194f695f0419c2db5d3467
+        sourceRevisionDigest: sha256:082ea6cf007b282f6c8ed83c0c444dcec872e4475d7dfe406b687fc55646a6dc
+        sourceBlobDigest: sha256:b5e808cce8225b044c356512b28ba189f97e5af6648c07aaf54fd837592e7f23
         codeSamplesNamespace: opal-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:346ca3e55b57f24f9ecc6ea2cf088afa92742c4ba977b68990733f4215138af4
+        codeSamplesRevisionDigest: sha256:beab7ee64d76861185673042bf1777f799451cb3b2eca4a3e14b13d9a066b9f8
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest
@@ -23,7 +23,9 @@ workflow:
             inputs:
                 - location: https://app.opal.dev/openapi.yaml
             overlays:
-                - location: mcp-overlay.yaml
+                - location: mcp-scopes-and-endpoints-overlay.yaml
+                - location: mcp-field-visibility-overlay.yaml
+                - location: mcp-documentation-overlay.yaml
             registry:
                 location: registry.speakeasyapi.dev/opal/opal/opal-api
     targets:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -5,7 +5,9 @@ sources:
         inputs:
             - location: https://app.opal.dev/openapi.yaml
         overlays:
-            - location: mcp-overlay.yaml
+            - location: mcp-scopes-and-endpoints-overlay.yaml
+            - location: mcp-field-visibility-overlay.yaml
+            - location: mcp-documentation-overlay.yaml
         registry:
             location: registry.speakeasyapi.dev/opal/opal/opal-api
 targets:

--- a/README.md
+++ b/README.md
@@ -411,7 +411,20 @@ run();
 
 ### [users](docs/sdks/users/README.md)
 
-* [user](docs/sdks/users/README.md#user) - Returns a `User` object.
+* [user](docs/sdks/users/README.md#user) - Retrieves detailed user information from Opal. This endpoint is designed for MCP (Mission Control Platform) integration
+to fetch user details by either user ID (UUID) or email address. The endpoint follows a strict precedence rule where
+user_id takes priority over email if both are provided.
+
+Key Implementation Notes:
+- Exactly one identifier (user_id OR email) must be provided
+- Returns a complete User object with all associated metadata
+- Suitable for user verification and profile data retrieval
+- Recommended for MCP user synchronization workflows
+
+Authentication:
+- Requires valid API authentication
+- Respects standard Opal authorization rules
+
 * [getUsers](docs/sdks/users/README.md#getusers) - Returns a list of users for your organization.
 * [getUserTags](docs/sdks/users/README.md#getusertags) - Returns all tags applied to the user.
 
@@ -543,7 +556,20 @@ To read more about standalone functions, check [FUNCTIONS.md](./FUNCTIONS.md).
 - [`uarsGetUARs`](docs/sdks/uars/README.md#getuars) - Returns a list of `UAR` objects.
 - [`usersGetUsers`](docs/sdks/users/README.md#getusers) - Returns a list of users for your organization.
 - [`usersGetUserTags`](docs/sdks/users/README.md#getusertags) - Returns all tags applied to the user.
-- [`usersUser`](docs/sdks/users/README.md#user) - Returns a `User` object.
+- [`usersUser`](docs/sdks/users/README.md#user) - Retrieves detailed user information from Opal. This endpoint is designed for MCP (Mission Control Platform) integration
+to fetch user details by either user ID (UUID) or email address. The endpoint follows a strict precedence rule where
+user_id takes priority over email if both are provided.
+
+Key Implementation Notes:
+- Exactly one identifier (user_id OR email) must be provided
+- Returns a complete User object with all associated metadata
+- Suitable for user verification and profile data retrieval
+- Recommended for MCP user synchronization workflows
+
+Authentication:
+- Requires valid API authentication
+- Respects standard Opal authorization rules
+
 - ~~[`groupsGetGroupReviewers`](docs/sdks/groups/README.md#getgroupreviewers)~~ - Gets the list of owner IDs of the reviewers for a group. :warning: **Deprecated**
 - ~~[`groupsGetGroupReviewerStages`](docs/sdks/groups/README.md#getgroupreviewerstages)~~ - Gets the list of reviewer stages for a group. :warning: **Deprecated**
 - ~~[`groupsSetGroupReviewers`](docs/sdks/groups/README.md#setgroupreviewers)~~ - Sets the list of reviewers for a group. :warning: **Deprecated**

--- a/docs/sdks/users/README.md
+++ b/docs/sdks/users/README.md
@@ -5,13 +5,39 @@
 
 ### Available Operations
 
-* [user](#user) - Returns a `User` object.
+* [user](#user) - Retrieves detailed user information from Opal. This endpoint is designed for MCP (Mission Control Platform) integration
+to fetch user details by either user ID (UUID) or email address. The endpoint follows a strict precedence rule where
+user_id takes priority over email if both are provided.
+
+Key Implementation Notes:
+- Exactly one identifier (user_id OR email) must be provided
+- Returns a complete User object with all associated metadata
+- Suitable for user verification and profile data retrieval
+- Recommended for MCP user synchronization workflows
+
+Authentication:
+- Requires valid API authentication
+- Respects standard Opal authorization rules
+
 * [getUsers](#getusers) - Returns a list of users for your organization.
 * [getUserTags](#getusertags) - Returns all tags applied to the user.
 
 ## user
 
-Returns a `User` object.
+Retrieves detailed user information from Opal. This endpoint is designed for MCP (Mission Control Platform) integration
+to fetch user details by either user ID (UUID) or email address. The endpoint follows a strict precedence rule where
+user_id takes priority over email if both are provided.
+
+Key Implementation Notes:
+- Exactly one identifier (user_id OR email) must be provided
+- Returns a complete User object with all associated metadata
+- Suitable for user verification and profile data retrieval
+- Recommended for MCP user synchronization workflows
+
+Authentication:
+- Requires valid API authentication
+- Respects standard Opal authorization rules
+
 
 ### Example Usage
 

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "opal-mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/mcp-documentation-overlay.yaml
+++ b/mcp-documentation-overlay.yaml
@@ -1,0 +1,171 @@
+openapi: 3.1.0
+overlay: 1.0.0
+info:
+  title: Update API documentation for MCP
+  version: 0.0.0
+actions:
+  - target: "$.paths['/user'].get"
+    update:
+      description: |
+        Retrieves detailed user information from Opal. This endpoint is designed for MCP (Mission Control Platform) integration
+        to fetch user details by either user ID (UUID) or email address. The endpoint follows a strict precedence rule where
+        user_id takes priority over email if both are provided.
+
+        Key Implementation Notes:
+        - Exactly one identifier (user_id OR email) must be provided
+        - Returns a complete User object with all associated metadata
+        - Suitable for user verification and profile data retrieval
+        - Recommended for MCP user synchronization workflows
+
+        Authentication:
+        - Requires valid API authentication
+        - Respects standard Opal authorization rules
+      parameters:
+        - name: user_id
+          in: query
+          description: |
+            Unique identifier (UUID) for the target user. When provided, this ID takes precedence over any email parameter.
+            Format: UUID v4
+            Example: "550e8400-e29b-41d4-a716-446655440000"
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: email
+          in: query
+          description: |
+            Email address of the target user. Only used when user_id is not provided.
+            Must be a valid email format.
+            Example: "user@example.com"
+            Note: This parameter is ignored if user_id is present.
+          required: false
+          schema:
+            type: string
+            format: email
+
+  - target: "#/components/schemas/PaginatedUsersList"
+    update:
+      description: |
+        Retrieves detailed user information from Opal. This endpoint is designed for MCP (Mission Control Platform) integration
+        to fetch user details by either user ID (UUID) or email address. The endpoint follows a strict precedence rule where
+        user_id takes priority over email if both are provided.
+
+        Key Implementation Notes:
+        - Exactly one identifier (user_id OR email) must be provided
+        - Returns a complete User object with all associated metadata
+        - Suitable for user verification and profile data retrieval
+        - Recommended for MCP user synchronization workflows
+
+        Authentication:
+        - Requires valid API authentication
+        - Respects standard Opal authorization rules
+
+        Integration Examples:
+        ```typescript
+        // Example 1: Fetch user by ID
+        const response = await opalClient.user.get({
+          userId: "29827fb8-f2dd-4e80-9576-28e31e9934ac"
+        });
+
+        // Example 2: Fetch user by email
+        const response = await opalClient.user.get({
+          email: "john.doe@company.dev"
+        });
+
+        // Example 3: MCP User Sync Implementation
+        async function syncUserWithMCP(mcpUserId: string) {
+          const opalUser = await opalClient.user.get({ userId: mcpUserId });
+          await mcpClient.updateUserAccess({
+            userId: mcpUserId,
+            accessStatus: opalUser.hr_idp_status,
+            metadata: {
+              position: opalUser.position,
+              email: opalUser.email
+            }
+          });
+        }
+        ```
+
+  - target: "#/components/schemas/User"
+    update:
+      description: |
+        # User Object
+        
+        ### Core Properties
+        - `user_id`: Unique identifier (UUID v4) for the user
+        - `email`: Primary email address, used for authentication and notifications
+        - `full_name`: Display name, combining first_name and last_name
+        - `position`: Organizational role or job title
+        - `hr_idp_status`: Current provisioning status from HR/IDP system
+        
+        ### MCP Integration Guidelines
+        1. User Synchronization:
+           - Match users by `user_id` as primary key
+           - Use email as secondary matching field
+           - Maintain hr_idp_status for access control decisions
+        
+        2. Status Handling:
+           - ACTIVE: Full system access granted
+           - SUSPENDED: Temporary access restriction
+           - DEPROVISIONED: Access removed but user record maintained
+           - DELETED: User record marked for removal
+           - NOT_FOUND: User doesn't exist in HR/IDP system
+        
+        ### Implementation Example
+        ```typescript
+        interface MCPUserSync {
+          async function mapOpalToMCPUser(opalUser: User): MCPUser {
+            return {
+              id: opalUser.user_id,
+              email: opalUser.email,
+              displayName: opalUser.full_name,
+              status: mapOpalStatus(opalUser.hr_idp_status),
+              metadata: {
+                position: opalUser.position,
+                firstName: opalUser.first_name,
+                lastName: opalUser.last_name
+              }
+            };
+          }
+          
+          function mapOpalStatus(status: UserHrIdpStatusEnum): MCPUserStatus {
+            const statusMap = {
+              ACTIVE: 'ENABLED',
+              SUSPENDED: 'SUSPENDED',
+              DEPROVISIONED: 'DISABLED',
+              DELETED: 'MARKED_FOR_DELETION',
+              NOT_FOUND: 'UNKNOWN'
+            };
+            return statusMap[status];
+          }
+        }
+        ```
+
+  - target: "#/components/schemas/UserHrIdpStatusEnum"
+    update:
+      description: |
+        Represents the current status of a user as reported by the HR/IDP provider.
+        
+        ### Status Definitions
+        - `ACTIVE`: User is currently employed and should have appropriate access
+        - `SUSPENDED`: User access temporarily restricted (e.g., leave of absence)
+        - `DEPROVISIONED`: User has been offboarded but record retained
+        - `DELETED`: User record has been removed from HR system
+        - `NOT_FOUND`: User doesn't exist in HR/IDP system
+        
+        ### MCP Status Handling
+        ```typescript
+        function handleUserStatusChange(user: User) {
+          switch (user.hr_idp_status) {
+            case 'ACTIVE':
+              return enableUserAccess(user.user_id);
+            case 'SUSPENDED':
+              return suspendUserAccess(user.user_id);
+            case 'DEPROVISIONED':
+            case 'DELETED':
+              return revokeUserAccess(user.user_id);
+            case 'NOT_FOUND':
+              return flagUserForReview(user.user_id);
+          }
+        }
+        ```

--- a/mcp-field-visibility-overlay.yaml
+++ b/mcp-field-visibility-overlay.yaml
@@ -1,0 +1,21 @@
+openapi: 3.1.0
+overlay: 1.0.0
+info:
+  title: Hide irrelevant fields
+  version: 0.0.0
+actions:
+  - target: "#/components/schemas/AddGroupUserRequest"
+    update:
+      hideFields: ["durationMinutes", "accessLevelRemoteId"]
+
+  - target: "#/components/schemas/AddResourceUserRequest"
+    update:
+      hideFields: ["durationMinutes", "accessLevelRemoteId"]
+
+  - target: "#/components/schemas/Resource"
+    update:
+      hideFields: ["remoteInfo", "resourceType", "resourceTypeId"]
+
+  - target: "#/components/schemas/Group"
+    update:
+      hideFields: ["remoteInfo", "groupType", "groupTypeId"]

--- a/mcp-scopes-and-endpoints-overlay.yaml
+++ b/mcp-scopes-and-endpoints-overlay.yaml
@@ -1,3 +1,4 @@
+openapi: 3.1.0
 overlay: 1.0.0
 info:
   title: Add MCP scopes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opal-mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opal-mcp",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "bin": {
         "mcp": "bin/mcp-server.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opal-mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Speakeasy",
   "type": "module",
   "bin": {

--- a/src/funcs/usersUser.ts
+++ b/src/funcs/usersUser.ts
@@ -25,7 +25,19 @@ import { APICall, APIPromise } from "../types/async.js";
 import { Result } from "../types/fp.js";
 
 /**
- * Returns a `User` object.
+ * Retrieves detailed user information from Opal. This endpoint is designed for MCP (Mission Control Platform) integration
+ * to fetch user details by either user ID (UUID) or email address. The endpoint follows a strict precedence rule where
+ * user_id takes priority over email if both are provided.
+ *
+ * Key Implementation Notes:
+ * - Exactly one identifier (user_id OR email) must be provided
+ * - Returns a complete User object with all associated metadata
+ * - Suitable for user verification and profile data retrieval
+ * - Recommended for MCP user synchronization workflows
+ *
+ * Authentication:
+ * - Requires valid API authentication
+ * - Respects standard Opal authorization rules
  */
 export function usersUser(
   client: OpalMcpCore,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -57,7 +57,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0",
-  sdkVersion: "0.0.2",
-  genVersion: "2.598.22",
-  userAgent: "speakeasy-sdk/typescript 0.0.2 2.598.22 1.0 opal-mcp",
+  sdkVersion: "0.0.3",
+  genVersion: "2.599.0",
+  userAgent: "speakeasy-sdk/typescript 0.0.3 2.599.0 1.0 opal-mcp",
 } as const;

--- a/src/mcp-server/mcp-server.ts
+++ b/src/mcp-server/mcp-server.ts
@@ -19,7 +19,7 @@ const routes = buildRouteMap({
 export const app = buildApplication(routes, {
   name: "mcp",
   versionInfo: {
-    currentVersion: "0.0.2",
+    currentVersion: "0.0.3",
   },
 });
 

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -140,7 +140,7 @@ export function createMCPServer(deps: {
 }) {
   const server = new McpServer({
     name: "OpalMcp",
-    version: "0.0.2",
+    version: "0.0.3",
   });
 
   const client = new OpalMcpCore({

--- a/src/mcp-server/tools/usersUser.ts
+++ b/src/mcp-server/tools/usersUser.ts
@@ -12,7 +12,21 @@ const args = {
 
 export const tool$usersUser: ToolDefinition<typeof args> = {
   name: "users-user",
-  description: `Returns a \`User\` object.`,
+  description:
+    `Retrieves detailed user information from Opal. This endpoint is designed for MCP (Mission Control Platform) integration
+to fetch user details by either user ID (UUID) or email address. The endpoint follows a strict precedence rule where
+user_id takes priority over email if both are provided.
+
+Key Implementation Notes:
+- Exactly one identifier (user_id OR email) must be provided
+- Returns a complete User object with all associated metadata
+- Suitable for user verification and profile data retrieval
+- Recommended for MCP user synchronization workflows
+
+Authentication:
+- Requires valid API authentication
+- Respects standard Opal authorization rules
+`,
   scopes: ["read"],
   args,
   tool: async (client, args, ctx) => {

--- a/src/sdk/users.ts
+++ b/src/sdk/users.ts
@@ -12,7 +12,19 @@ import { unwrapAsync } from "../types/fp.js";
 
 export class Users extends ClientSDK {
   /**
-   * Returns a `User` object.
+   * Retrieves detailed user information from Opal. This endpoint is designed for MCP (Mission Control Platform) integration
+   * to fetch user details by either user ID (UUID) or email address. The endpoint follows a strict precedence rule where
+   * user_id takes priority over email if both are provided.
+   *
+   * Key Implementation Notes:
+   * - Exactly one identifier (user_id OR email) must be provided
+   * - Returns a complete User object with all associated metadata
+   * - Suitable for user verification and profile data retrieval
+   * - Recommended for MCP user synchronization workflows
+   *
+   * Authentication:
+   * - Requires valid API authentication
+   * - Respects standard Opal authorization rules
    */
   async user(
     request: operations.UserRequest,


### PR DESCRIPTION
This PR refactors our server generation process by splitting the monolithic overlay file into three distinct, purpose-focused overlays:
`mcp-scopes-and-endpoints-overlay.yaml` - Controls which endpoints are exposed to the MCP server
`mcp-field-visibility-overlay.yaml` - Manages field visibility in API responses
`mcp-documentation-overlay.yaml` - Provides MCP-specific documentation annotations

**Why This Change?**
Improved Maintainability: Each overlay now has a single, clear responsibility
Better Collaboration: Teams can work on separate overlays without merge conflicts
Easier Debugging: When generation issues occur, it's faster to identify which overlay needs attention
Reduced Cognitive Load: Developers can focus on one aspect of the API at a time

**Implementation Details**
The Speakeasy generator now processes these three separate overlay files in sequence, maintaining the same functionality as before while providing better organization and clarity.

**Testing**
Server generation has been verified with the new overlay structure, and all existing MCP functionality continues to work as expected.